### PR TITLE
remove prng store, update create viewing key to make entropy optional

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -4,7 +4,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{batch, transaction_history::Tx};
-use cosmwasm_std::{Addr, Api, Binary, StdError, StdResult, Uint128, Uint64};
+use cosmwasm_std::{Addr, Api, Binary, StdError, StdResult, Uint128,};
+#[cfg(feature = "gas_evaporation")]
+use cosmwasm_std::Uint64;
 use secret_toolkit::permit::Permit;
 
 #[cfg_attr(test, derive(Eq, PartialEq))]
@@ -146,7 +148,7 @@ pub enum ExecuteMsg {
         padding: Option<String>,
     },
     CreateViewingKey {
-        entropy: String,
+        entropy: Option<String>,
         #[cfg(feature = "gas_evaporation")]
         gas_target: Option<Uint64>,
         padding: Option<String>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,14 +4,12 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Addr, StdError, StdResult, Storage};
 use secret_toolkit::serialization::Json;
 use secret_toolkit::storage::{Item, Keymap, Keyset};
-use secret_toolkit_crypto::SHA256_HASH_SIZE;
 
 use crate::msg::ContractStatusLevel;
 
 pub const KEY_CONFIG: &[u8] = b"config";
 pub const KEY_TOTAL_SUPPLY: &[u8] = b"total_supply";
 pub const KEY_CONTRACT_STATUS: &[u8] = b"contract_status";
-pub const KEY_PRNG: &[u8] = b"prng";
 pub const KEY_MINTERS: &[u8] = b"minters";
 pub const KEY_TX_COUNT: &[u8] = b"tx-count";
 
@@ -54,22 +52,9 @@ pub static TOTAL_SUPPLY: Item<u128> = Item::new(KEY_TOTAL_SUPPLY);
 
 pub static CONTRACT_STATUS: Item<ContractStatusLevel, Json> = Item::new(KEY_CONTRACT_STATUS);
 
-pub static PRNG: Item<[u8; SHA256_HASH_SIZE]> = Item::new(KEY_PRNG);
-
 pub static MINTERS: Item<Vec<Addr>> = Item::new(KEY_MINTERS);
 
 pub static TX_COUNT: Item<u64> = Item::new(KEY_TX_COUNT);
-
-pub struct PrngStore {}
-impl PrngStore {
-    pub fn load(store: &dyn Storage) -> StdResult<[u8; SHA256_HASH_SIZE]> {
-        PRNG.load(store).map_err(|_err| StdError::generic_err(""))
-    }
-
-    pub fn save(store: &mut dyn Storage, prng_seed: [u8; SHA256_HASH_SIZE]) -> StdResult<()> {
-        PRNG.save(store, &prng_seed)
-    }
-}
 
 pub struct MintersStore {}
 impl MintersStore {


### PR DESCRIPTION
This PR makes the following changes:

- uses env seed for rng in `execute`
- removes legacy PRNG from store.rs as it is no longer needed
- during initialization creates viewing key of contract using hkdf key derivation
- makes `entropy` field optional in `create_viewing_key` by adding random bytes from vrf